### PR TITLE
Changed the submodule repository to a public repository using HTTPS.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/metadata-manager"]
 	path = third_party/metadata-manager
-	url = git@github.com:project-tsurugi/metadata-manager.git
+	url = https://github.com/project-tsurugi/metadata-manager.git


### PR DESCRIPTION
サブモジュールリポジトリURLをSSHからHTTPSを使用した公開リポジトリに変更しました。
https://github.com/project-tsurugi/tsurugi-issues/issues/913#issuecomment-2345300654


本対処を適用したtsurugi_fdwのブランチ（[fix/message_gitmodules](https://github.com/project-tsurugi/tsurugi_fdw/tree/fix/message_gitmodules)）で問題ないことを確認しています。

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           16 ms
test create_table                 ... ok          766 ms
test create_index                 ... ok         1462 ms
test insert_select_happy          ... ok         1059 ms
test update_delete                ... ok          568 ms
test select_statements            ... ok          500 ms
test user_management              ... ok          223 ms
test udf_transaction              ... ok          820 ms
test prepare_statment             ... ok         2078 ms
test prepare_select_statment      ... ok         2127 ms
test prepare_decimal              ... ok         1107 ms
test manual_tutorial              ... ok          311 ms
test data_types                   ... ok          300 ms

======================
 All 13 tests passed.
======================
~~~

BUILD_TIMESTAMP:202410071808
###### tsurugi_fdw and dependent modules
- tsurugi_fdw [c711fa0 - Merge pull request #180 from project-tsurugi/fix/error_notification](https://github.com/project-tsurugi/tsurugi_fdw/commit/c711fa0af4c967f00cf7318212a2e8d281cf0727)
- metadata-manager [773fad5 - Merge pull request #114 from project-tsurugi/dev/timezone](https://github.com/project-tsurugi/metadata-manager/commit/773fad52379f4231f27d4f4e40cf52d9f3bd9b61)
- **message-manager [903c6f3 - Changed the submodule repository to a public repository using HTTPS.](https://github.com/project-tsurugi/message-manager/commit/903c6f383c6c61ae12f1404163ab879773d3b6d0)**
- ogawayama [68e9d07 - Merge pull request #108 from project-tsurugi/wip/i_975](https://github.com/project-tsurugi/ogawayama/commit/68e9d07ff782b783ae8555668a30d5ab8f421829)
- takatori [89801e4 - fix: correct `variable_declarator::value()`.](https://github.com/project-tsurugi/takatori/commit/89801e44dc40a508d03a8f06edd033b96e281069)
